### PR TITLE
Add color to logger messages in windows terminals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /.clangd
 compile_commands.json
+run.bat
+test.bat

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16) #3.16 needed for precompiled headers
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/include/lf/lefaye.hpp
+++ b/include/lf/lefaye.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <cstdint>
 
 namespace lf {

--- a/include/lf/lefaye.hpp
+++ b/include/lf/lefaye.hpp
@@ -4,6 +4,4 @@ namespace lf {
   void init(const char* title, uint32_t width, uint32_t height);
   void shutdown();
   bool update();
-
-  int add_vals(int a, int b);
 }

--- a/include/lf/log.hpp
+++ b/include/lf/log.hpp
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <array>
 #include <string_view>
 

--- a/include/lf/log.hpp
+++ b/include/lf/log.hpp
@@ -14,16 +14,27 @@ namespace lf::log {
   };
 
   enum class Color : uint8_t {
+#ifdef LF_WIN32
     kBlack = 0,
     kBlue,
     kGreen,
-    kLightBlue,
+    kCyan,
     kRed,
-    kPurple,
+    kMagenta,
     kYellow,
     kWhite,
+#else
+    kBlack = 30,
+    kRed,
+    kGreen,
+    kYellow,
+    kBlue,
+    kMagenta,
+    kCyan,
+    kWhite,
+#endif
   };
-  
+
   constexpr std::array<const char*, 3> levelPrefixes = {
     "[INFO]:  ",
     "[WARN]:  ",
@@ -31,7 +42,7 @@ namespace lf::log {
   };
 
   constexpr std::array<log::Color, 3> levelColors = {
-    log::Color::kLightBlue,
+    log::Color::kCyan,
     log::Color::kYellow,
     log::Color::kRed
   };

--- a/include/lf/log.hpp
+++ b/include/lf/log.hpp
@@ -3,80 +3,56 @@
 #include <array>
 #include <string_view>
 
-#ifdef LF_WIN32
-  #include <Windows.h>
-#endif
-
 #include <fmt/format.h>
 
 namespace lf::log {
 
-  enum class Level {
+  enum class Level : uint8_t {
     kInfo = 0,
     kWarn,
-    kError
+    kError,
   };
 
-  enum class Color {
-    kDefault = 0,
-    kBlue = 36,
-    kYellow = 33,
-    kRed = 31,
+  enum class Color : uint8_t {
+    kBlack = 0,
+    kBlue,
+    kGreen,
+    kLightBlue,
+    kRed,
+    kPurple,
+    kYellow,
+    kWhite,
+  };
+  
+  constexpr std::array<const char*, 3> levelPrefixes = {
+    "[INFO]:  ",
+    "[WARN]:  ",
+    "[ERROR]: "
   };
 
-  namespace internal {
-    constexpr std::array<const char*, 3> prefixStrings = {
-      "[INFO]:  ",
-      "[WARN]:  ",
-      "[ERROR]: "
-    };
+  constexpr std::array<log::Color, 3> levelColors = {
+    log::Color::kLightBlue,
+    log::Color::kYellow,
+    log::Color::kRed
+  };
 
-#ifdef LF_WIN32
-    HANDLE consoleHandle;
-#endif
+  void init();
 
-    inline void setColor(log::Color color) {
-#ifdef LF_WIN32
-      SetConsoleTextAttribute(consoleHandle, FOREGROUND_BLUE);
-#else
-      fmt::print("\033[0;{}m", static_cast<uint32_t> color);
-#endif
-    }
-
-    inline void vLogMessage(log::Level severity, std::string_view format, fmt::format_args args) {
-      setColor(log::Color::kRed);
-      fmt::vprint(
-        fmt::format("{} {}\n",
-          prefixStrings[static_cast<uint32_t>(severity)],
-          format),
-        args);
-      fmt::print("{}\n", FOREGROUND_RED);
-      fmt::print("{}\n", FOREGROUND_BLUE);
-      fmt::print("{}\n", FOREGROUND_GREEN);
-      fmt::print("{}\n", FOREGROUND_INTENSITY);
-      setColor(log::Color::kDefault);
-    }
-  }
- 
-  inline void init() {
-#ifdef LF_WIN32
-    internal::consoleHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-#endif
-  }
+  void vLogMessage(log::Level severity, std::string_view format, fmt::format_args args);
 
   template<typename... Args>
   void info(std::string_view format, const Args&... args) {
-    internal::vLogMessage(log::Level::kInfo, format, fmt::make_format_args(args...));
+    vLogMessage(log::Level::kInfo, format, fmt::make_format_args(args...));
   }
 
   template <typename... Args>
   void warn(std::string_view format, const Args&... args) {
-    internal::vLogMessage(log::Level::kWarn, format, fmt::make_format_args(args...));
+    vLogMessage(log::Level::kWarn, format, fmt::make_format_args(args...));
   }
 
   template<typename... Args>
   void error(std::string_view format, const Args&... args) {
-    internal::vLogMessage(log::Level::kError, format, fmt::make_format_args(args...));
+    vLogMessage(log::Level::kError, format, fmt::make_format_args(args...));
   }
 }
 

--- a/include/lf/os/window.hpp
+++ b/include/lf/os/window.hpp
@@ -6,7 +6,15 @@
 #endif
 
 namespace lf::os {
-  void createWindow(const char* title, uint32_t width, uint32_t height);
-  void destroyWindow();
-  bool updateWindow();
+  class Window {
+  public:
+    Window();
+    virtual ~Window();
+
+    bool create(const char* title, uint32_t width, uint32_t height);
+    void destroy();
+    bool update();
+  protected:
+    HWND handle = NULL;
+  };
 }

--- a/include/lf/os/window.hpp
+++ b/include/lf/os/window.hpp
@@ -12,9 +12,15 @@ namespace lf::os {
     virtual ~Window();
 
     bool create(const char* title, uint32_t width, uint32_t height);
-    void destroy();
+    bool destroy();
     bool update();
+
+    bool isOpen();
   protected:
     HWND handle = NULL;
+  };
+
+  inline bool Window::isOpen() {
+    return handle != NULL;
   };
 }

--- a/include/lf/pch.hpp
+++ b/include/lf/pch.hpp
@@ -1,0 +1,14 @@
+#pragma once
+//pch.hpp - precompiled headers for lefaye
+
+//standard library headers
+#include <cstdio>
+#include <cstdint>
+
+//external apis
+#ifdef LF_WIN32
+  #define WIN32_LEAN_AND_MEAN
+  #include <Windows.h>
+#endif
+
+#include <vulkan/vulkan.h>

--- a/include/lf/pch.hpp
+++ b/include/lf/pch.hpp
@@ -4,6 +4,7 @@
 //standard library headers
 #include <cstdio>
 #include <cstdint>
+#include <array>
 
 //external apis
 #ifdef LF_WIN32

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(lefaye core.cpp gfx.cpp os/window.cpp os/file.cpp)
+add_library(lefaye log.cpp core.cpp gfx.cpp os/window.cpp os/file.cpp)
 
 target_precompile_headers(lefaye PRIVATE ../include/lf/pch.hpp)
 target_include_directories(lefaye PUBLIC fmt::fmt ../include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(lefaye core.cpp gfx.cpp os/window.cpp os/file.cpp)
 
+target_precompile_headers(lefaye PRIVATE ../include/lf/pch.hpp)
 target_include_directories(lefaye PUBLIC fmt::fmt ../include)
 target_link_libraries(lefaye PRIVATE Vulkan::Vulkan fmt::fmt)
 target_compile_features(lefaye PUBLIC cxx_std_17)

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1,10 +1,9 @@
+#include "lf/pch.hpp"
 #include "lf/lefaye.hpp"
 #include "lf/log.hpp"
+#include "lf/gfx.hpp"
 #include "lf/os/window.hpp"
 #include "lf/os/file.hpp"
-#include "lf/gfx.hpp"
-
-#include <cstdio>
 
 namespace lf {
   os::File file;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -8,6 +8,7 @@
 
 namespace lf {
   os::File file;
+  os::Window window;
 
   void init(const char* title, uint32_t width, uint32_t height) {
     log::info("Initializing LeFaye. Title: {}, Screen is {}x{}",
@@ -22,26 +23,21 @@ namespace lf {
       fmt::print(buf);
     }
 
-    os::createWindow(title, width, height);
+    window.create(title, width, height);
     uint32_t result = gfx::init(title);
   }
 
   void shutdown() {
     file.close();
     gfx::shutdown();
-    os::destroyWindow();
+    window.destroy();
   }
 
   bool update() {
-    if(!os::updateWindow())
+    if(!window.update())
       return false;
 
     gfx::draw();
-
-     return true;
-  }
-
-  int add_vals(int a, int b) {
-    return a + b;
+    return true;
   }
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -10,6 +10,7 @@ namespace lf {
   os::Window window;
 
   void init(const char* title, uint32_t width, uint32_t height) {
+    log::init();
     log::info("Initializing LeFaye. Title: {}, Screen is {}x{}",
         title, width, height);
 

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1,7 +1,5 @@
-#include "lf/gfx.hpp"
+#include "lf/pch.hpp"
 #include "lf/log.hpp"
-
-#include <vulkan/vulkan.h>
 
 namespace lf::gfx {
   VkInstance instance;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -9,9 +9,9 @@ namespace lf::log {
 
   void setColor(log::Color color) {
 #ifdef LF_WIN32
-    SetConsoleTextAttribute(consoleHandle, static_cast<uint32_t>(color));
+    SetConsoleTextAttribute(consoleHandle, static_cast<uint8_t>(color));
 #else
-    fmt::print("\033[0;{}m", static_cast<uint32_t> color);
+    fmt::print("\033[0;{}m", static_cast<uint8_t> color);
 #endif
   }
 
@@ -19,7 +19,7 @@ namespace lf::log {
     setColor(levelColors[static_cast<uint8_t>(severity)]);
     fmt::vprint(
       fmt::format("{} {}\n",
-        levelPrefixes[static_cast<uint32_t>(severity)],
+        levelPrefixes[static_cast<uint8_t>(severity)],
         format),
       args);
     setColor(log::Color::kWhite);

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,0 +1,33 @@
+#include "lf/pch.hpp"
+#include "lf/log.hpp"
+
+namespace lf::log {
+
+#ifdef LF_WIN32
+  HANDLE consoleHandle = INVALID_HANDLE_VALUE;
+#endif
+
+  void setColor(log::Color color) {
+#ifdef LF_WIN32
+    SetConsoleTextAttribute(consoleHandle, static_cast<uint32_t>(color));
+#else
+    fmt::print("\033[0;{}m", static_cast<uint32_t> color);
+#endif
+  }
+
+  void vLogMessage(log::Level severity, std::string_view format, fmt::format_args args) {
+    setColor(levelColors[static_cast<uint8_t>(severity)]);
+    fmt::vprint(
+      fmt::format("{} {}\n",
+        levelPrefixes[static_cast<uint32_t>(severity)],
+        format),
+      args);
+    setColor(log::Color::kWhite);
+  }
+
+  void init() {
+#ifdef LF_WIN32
+    consoleHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+#endif
+  }
+}

--- a/src/os/file.cpp
+++ b/src/os/file.cpp
@@ -1,9 +1,6 @@
+#include "lf/pch.hpp"
 #include "lf/os/file.hpp"
 #include "lf/log.hpp"
-
-#include <cstdint>
-
-#include <windows.h>
 
 namespace lf::os {
 

--- a/src/os/window.cpp
+++ b/src/os/window.cpp
@@ -1,13 +1,11 @@
+#include "lf/pch.hpp"
 #include "lf/os/window.hpp"
 #include "lf/log.hpp"
-
-#include <cstdint>
-
-#include <windows.h>
 
 namespace lf::os {
 
   LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
+    log::info("window message received");
     switch(message) {
       case WM_SIZE:
         return 0;

--- a/src/os/window.cpp
+++ b/src/os/window.cpp
@@ -6,7 +6,6 @@
 #include <windows.h>
 
 namespace lf::os {
-  HWND handle = NULL;
 
   LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
     switch(message) {
@@ -21,8 +20,15 @@ namespace lf::os {
     return DefWindowProc(hwnd, message, wParam, lParam);
   }
 
+  Window::Window() :
+    handle(NULL)
+    {}
 
-  void createWindow(const char* title, uint32_t width, uint32_t height) {
+  Window::~Window() {
+    destroy();
+  }
+
+  bool Window::create(const char* title, uint32_t width, uint32_t height) {
     WNDCLASSEX wc = {};
     wc.cbSize = sizeof(WNDCLASSEX);
     wc.style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
@@ -33,7 +39,7 @@ namespace lf::os {
 
     RegisterClassEx(&wc);
 
-    HWND handle = CreateWindowEx(
+    handle = CreateWindowEx(
         0,
         "LFWindowClass",
         title,
@@ -46,10 +52,17 @@ namespace lf::os {
         NULL
         );
 
+    if(handle == NULL) {
+      log::error("Failed to open window!");
+      return false;
+    }
+
     ShowWindow(handle, SW_SHOW);
+
+    return true;
   }
 
-  bool updateWindow() {
+  bool Window::update() {
     MSG msg;
     while(PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
       if(msg.message == WM_QUIT) {
@@ -63,7 +76,7 @@ namespace lf::os {
     return true;
   }
 
-  void destroyWindow() {
+  void Window::destroy(){
     PostQuitMessage(0);
   }
 }

--- a/src/os/window.cpp
+++ b/src/os/window.cpp
@@ -5,7 +5,6 @@
 namespace lf::os {
 
   LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
-    log::info("window message received");
     switch(message) {
       case WM_SIZE:
         return 0;

--- a/src/os/window.cpp
+++ b/src/os/window.cpp
@@ -25,10 +25,17 @@ namespace lf::os {
     {}
 
   Window::~Window() {
-    destroy();
+    if(isOpen()) {
+      destroy();
+    }
   }
 
   bool Window::create(const char* title, uint32_t width, uint32_t height) {
+    if(isOpen()) {
+      log::error("Cannot create window. Already created!");
+      return false;
+    }
+
     WNDCLASSEX wc = {};
     wc.cbSize = sizeof(WNDCLASSEX);
     wc.style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC;
@@ -63,6 +70,11 @@ namespace lf::os {
   }
 
   bool Window::update() {
+    if(handle == NULL) {
+      log::error("Unable to update window. No window is open!");
+      return false;
+    }
+
     MSG msg;
     while(PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
       if(msg.message == WM_QUIT) {
@@ -76,7 +88,13 @@ namespace lf::os {
     return true;
   }
 
-  void Window::destroy(){
-    PostQuitMessage(0);
+  bool Window::destroy(){
+    if(handle == NULL) {
+      log::error("Unable to destroy window. No window is open!");
+      return false;
+    }
+    DestroyWindow(handle);
+    handle = NULL;
+    return true;
   }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,3 +36,4 @@ function(vkp_add_test TESTDIR TESTNAME)
 endfunction()
 
 vkp_add_test(os file-test)
+vkp_add_test(os window-test)

--- a/tests/os/window-test.cpp
+++ b/tests/os/window-test.cpp
@@ -3,7 +3,37 @@
 
 using namespace lf::os;
 
-TEST(window, constructor) {
- createWindow("Hello World", 640, 480);
- destroyWindow();
+TEST(Window, Create) {
+  Window w;
+  bool result = w.create("Hello", 0, 0);
+  ASSERT_EQ(result, true);
+}
+
+TEST(Window, IsOpen) {
+  Window w;
+  ASSERT_EQ(w.isOpen(), false);
+  w.create("TestWindow", 640, 480);
+  ASSERT_EQ(w.isOpen(), true);
+  w.destroy();
+  ASSERT_EQ(w.isOpen(), false);
+}
+
+TEST(Window, Destroy) {
+  Window w;
+  bool result = w.destroy();
+  ASSERT_EQ(result, false);
+  w.create("TestWindow", 640, 480);
+  result = w.destroy();
+  ASSERT_EQ(result, true);
+}
+
+TEST(Window, Update) {
+  Window w;
+  bool result = w.update();
+  ASSERT_EQ(result, false);
+
+  w.create("TestWindow", 640, 480);
+
+  result = w.update();
+  ASSERT_EQ(result, true);
 }


### PR DESCRIPTION
currently the ANSI escape codes used to add color to log messages don't work and output garbage instead. The logger has been modified to use the win32 api's SetConsoleTextAttribute